### PR TITLE
Fix bug and race condition in multi-account password checking.

### DIFF
--- a/lib/PasswordStrategy.js
+++ b/lib/PasswordStrategy.js
@@ -48,7 +48,8 @@ function Strategy(options) {
             sysPassword: password
           }, function(err, verified) {
             if(err) {
-              return callback(err);
+              // FIXME: Ignore errors to ensure all IDs are checked
+              return callback();
             }
             if(verified) {
               matches.push(id);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -486,6 +486,12 @@ function _verifyPasswordHash(identity, type, callback) {
           'Could not verify Identity ' + type + '. Identity is not active.',
           'IdentityInactive'));
       }
+      if(!record.meta['bedrock-authn-password']) {
+        return callback(new BedrockError(
+          'Could not verify Identity ' + type +
+          '. Password-based authentication disabled.',
+          'MethodNotAllowed'));
+      }
       callback(null, record.meta['bedrock-authn-password'][field]);
     },
     function(hash, callback) {


### PR DESCRIPTION
We have two issues with the way we process password authentication in this module:

1. We assume every account has a record.meta['bedrock-authn-password'] entry, which is a bad assumption to make. Not all identities will use password-based authentication. Some identities will specifically disallow it.
2. There is a race condition via async.each() that causes password matching to exit early when the first match fails.

This PR fixes both of those issues.