### PR TITLE
Update bcrypt dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-authn-password",
   "dependencies": {
     "async": "^1.5.2",
-    "bcrypt": "~0.8.5",
+    "bcrypt": "^2.0.0",
     "lodash": "^4.6.1",
     "passport-local": "^1.0.0"
   },


### PR DESCRIPTION
Update/merge/release this when this issue is resolved: https://github.com/digitalbazaar/bedrock-authn-password/issues/21

Also need to ensure that we fully understand the implications of `bcrypt` changing the default to a `2b` flavor.  They say that 1.x hashes are compatible with 2.x but not the reverse.  Also, `bcrypt` docs warn that implementations can vary.  Is 2.x compatible with the bcrypt being used in the front-end?